### PR TITLE
fixes for windows

### DIFF
--- a/src/chrome/content/preferencesWindow.xul
+++ b/src/chrome/content/preferencesWindow.xul
@@ -12,6 +12,7 @@
       <preference id="passff-passwordFieldNames-pref" name="extensions.passff.passwordFieldNames" type="string" />
       <preference id="passff-urlFieldNames-pref" name="extensions.passff.urlFieldNames" type="string" />
       <preference id="passff-command-pref" name="extensions.passff.command" type="string" />
+      <preference id="passff-commandArgs-pref" name="extensions.passff.commandArgs" type="string" />
       <preference id="passff-home-pref" name="extensions.passff.home" type="string" />
       <preference id="passff-gpg_agent_info-pref" name="extensions.passff.gpgAgentInfo" type="string" />
       <preference id="passff-pass_dir-pref" name="extensions.passff.storeDir" type="string" />
@@ -113,6 +114,12 @@
             <vbox>
               <label tooltiptext= "&passff.preferences.command_tooltip;" id="command_label" control="command" value="&passff.preferences.command_label;"/>
               <textbox tooltiptext= "&passff.preferences.command_tooltip;" id="command" preference="passff-command-pref" type="string"/>
+            </vbox>
+          </row>
+          <row>
+            <vbox>
+              <label tooltiptext= "&passff.preferences.commandArgs_tooltip;" id="commandArgs_label" control="commandArgs" value="&passff.preferences.commandArgs_label;"/>
+              <textbox tooltiptext= "&passff.preferences.commandArgs_tooltip;" id="commandArgs" preference="passff-commandArgs-pref" type="string"/>
             </vbox>
           </row>
           <row>

--- a/src/chrome/locale/en-US/preferences.dtd
+++ b/src/chrome/locale/en-US/preferences.dtd
@@ -14,6 +14,8 @@
 <!ENTITY passff.preferences.url_field_names_tooltip      "Comma separated list of field names. The first matching field in the url data will be used as login">
 <!ENTITY passff.preferences.command_label                "Pass command">
 <!ENTITY passff.preferences.command_tooltip              "The pass script path">
+<!ENTITY passff.preferences.commandArgs_label                "Pass command line arguments">
+<!ENTITY passff.preferences.commandArgs_tooltip              "The pass command line arguments">
 <!ENTITY passff.preferences.home_label                   "User home">
 <!ENTITY passff.preferences.home_tooltip                 "User home. If empty, use environment user home">
 <!ENTITY passff.preferences.gpg_agent_info_label         "Gpg agent info file">

--- a/src/modules/pass.js
+++ b/src/modules/pass.js
@@ -84,6 +84,10 @@ PassFF.Pass = {
     let stdout = result.stdout;
     this._rootItems = [];
     this._items = [];
+    // replace utf8 box characters with traditional ascii tree
+    stdout = stdout.replace(/[\u2514\u251C]\u2500\u2500/g,"|--");
+    //remove colors
+    stdout = stdout.replace(/\x1B\[[^m]*m/g, "");
     //console.debug("[PassFF]", stdout);
     let lines = stdout.split("\n");
     let re = /(.*[|`])+-- (.*)/;
@@ -179,9 +183,16 @@ PassFF.Pass = {
 
   executePass : function(arguments) {
     let result = null;
+    let args = new Array();
+    PassFF.Preferences.commandArgs.forEach(function(val){
+        args.push(val);
+    });
+    arguments.forEach(function(val){
+        args.push(val);
+    })
     let params = {
       command     : PassFF.Preferences.command,
-      arguments   : arguments,
+      arguments   : args,
       environment : this.getEnvParams(),
       charset     : 'UTF-8',
       workdir     : PassFF.Preferences.home,

--- a/src/modules/preferences.js
+++ b/src/modules/preferences.js
@@ -11,6 +11,7 @@ PassFF.Preferences = {
         passwordFieldNames : "passwd,password,pass",
         urlFieldNames      : "url,http",
         command            : "/usr/bin/pass",
+        commandArgs        : "",
         home               : "",
         storeDir           : "",
         storeGit           : "",
@@ -43,6 +44,7 @@ PassFF.Preferences = {
             passwordFieldNames : this.passwordFieldNames,
             urlFieldNames      : this.urlFieldNames,
             command            : this.command,
+            commandArgs        : this.commandArgs,
             home               : this.home,
             storeDir           : this.storeDir,
             storeGit           : this.storeGit,
@@ -60,6 +62,7 @@ PassFF.Preferences = {
     get passwordFieldNames() { return this._params.passwordFieldNames.value.split(",");},
     get urlFieldNames()      { return this._params.urlFieldNames.value.split(",");},
     get command()            { return this._params.command.value; },
+    get commandArgs()        { return this._params.commandArgs.value.split(" "); },
     get home()               { return (this._params.home.value.trim().length > 0 ? this._params.home.value : this._environment.get('HOME')); },
     get storeDir()           { return (this._params.storeDir.value.trim().length > 0 ? this._params.storeDir.value : this._environment.get('PASSWORD_STORE_DIR')); },
     get storeGit()           { return (this._params.storeGit.value.trim().length > 0 ? this._params.storeGit.value : this._environment.get('PASSWORD_STORE_GIT')); },
@@ -71,7 +74,7 @@ PassFF.Preferences = {
 
     setGpgAgentEnv : function() {
         let gpgAgentInfo = this._params.gpgAgentInfo.value;
-        let filename = (gpgAgentInfo.indexOf("/") != 0 ? this.home + "/" : "") + gpgAgentInfo;
+        let filename = (gpgAgentInfo.indexOf(FileUtils.directorySeparator) != 0 ? this.home + FileUtils.directorySeparator : "") + gpgAgentInfo;
         let file = new FileUtils.File(filename);
         console.debug("[PassFF]", "Check Gpg agent file existance : " + filename);
         if (file.exists() && file.isFile()) {


### PR DESCRIPTION
directory separator should work on windows now
added possibility to pass CLI arguments to pass command
will remove colors before processing pass output
will replace unicode tree with ascii key before processing pass output
