### PR TITLE
Tab sensitive load event handling.

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -3,5 +3,6 @@ TARGET = ../bin/passff.xpi
 all: xpi
 
 xpi:
+	mkdir -p `dirname $(TARGET)`
 	rm -f $(TARGET)
 	zip -r $(TARGET) bootstrap.js install.rdf chrome.manifest icon.png chrome modules

--- a/src/bootstrap.js
+++ b/src/bootstrap.js
@@ -241,22 +241,23 @@ let PassFF = {
             let win = doc.defaultView;
             if (doc.nodeName == "#document" && win == win.top) {
                 console.debug("[PassFF]", "Content loaded", event, PassFF.Preferences.autoFill, PassFF.Page.getPasswordInputs(doc).length);
-
-                if ((PassFF.Page.itemToUse || PassFF.Preferences.autoFill) && PassFF.Page.getPasswordInputs(doc).length > 0) {
+                
+                if(!PassFF.Page.autoFillAndSubmitPending 
+                   && PassFF.Preferences.autoFill
+                   && PassFF.Page.getPasswordInputs(doc).length > 0) {
                     let url = win.location.href
                     let matchItems = PassFF.Pass.getUrlMatchingItems(url);
 
-                    console.info("[PassFF]", "Start auto-fill")
-                    let bestFitItem = PassFF.Page.itemToUse;
-                    if (!bestFitItem) bestFitItem = PassFF.Pass.findBestFitItem(matchItems, url);
+                    console.info("[PassFF]", "Start pref-auto-fill")
+                    let bestFitItem = PassFF.Pass.findBestFitItem(matchItems, url);
 
                     if(bestFitItem) {
                         PassFF.Page.fillInputs(doc, bestFitItem);
-                        if (PassFF.Page.itemToUse || (PassFF.Preferences.autoSubmit && PassFF.Pass.getItemsLeafs(matchItems).length == 1)) PassFF.Page.submit(doc, url);
+                        if (PassFF.Preferences.autoSubmit && PassFF.Pass.getItemsLeafs(matchItems).length == 1)
+                            PassFF.Page.submit(doc, url);
                     }
                 }
-
-                PassFF.Page.itemToUse = null;
+                
                 PassFF.Page._autoSubmittedUrls = new Array();
             }
         },

--- a/src/bootstrap.js
+++ b/src/bootstrap.js
@@ -257,7 +257,7 @@ let PassFF = {
                             PassFF.Page.submit(doc, url);
                     }
                 }
-                
+
                 PassFF.Page._autoSubmittedUrls = new Array();
             }
         },

--- a/src/modules/menu.js
+++ b/src/modules/menu.js
@@ -311,7 +311,6 @@ PassFF.Menu = {
         if (item == null || item == undefined) return;
 
         console.debug("[PassFF]", "go to item url", item, newTab, autoFillAndSubmit);
-        if (autoFillAndSubmit) PassFF.Page.itemToUse = item;
         let passwordData = PassFF.Pass.getPasswordData(item);
         let url = passwordData.url;
         if (url == null || url == undefined) url = item.key;
@@ -323,6 +322,19 @@ PassFF.Menu = {
             } else {
                 window.content.location.href = url;
             }
+            if(autoFillAndSubmit) {
+                PassFF.Page.autoFillAndSubmitPending = true;
+                let currentTabBrowser = window.gBrowser.getBrowserForTab(window.gBrowser.selectedTab);
+                currentTabBrowser.addEventListener("load", function load(event) {
+                    console.info("[PassFF]", "Start auto-fill")
+                    currentTabBrowser.removeEventListener("load", load, true);
+                    PassFF.Page.autoFillAndSubmitPending = false;
+                    let doc = event.originalTarget;
+                    PassFF.Page.fillInputs(doc, item);
+                    PassFF.Page.submit(doc, url);
+                }, true);
+            }
+            
         }
     },
 

--- a/src/modules/page.js
+++ b/src/modules/page.js
@@ -1,6 +1,6 @@
 PassFF.Page = {
   _autoSubmittedUrls : new Array(),
-  itemToUse : null,
+  autoFillAndSubmitPending : false,
   init : function() { },
 
   fillInputs : function(doc, item) {


### PR DESCRIPTION
It frequently occurs to me that the "Goto, Fill And Submit"-feature doesn't work as expected. It will only wait for _any_ of the currently open tabs to load and then fill in credentials for that particular tab. That's of course problematic whenever there are several tabs loading at the time when the "Goto, Fill And Submit" is fired. 

The proposed patch is far from the most elegant solution and it might still be problematic in some cases. But it works for me. (Especially, because I'm not using the preference "Try to auto fill page forms".)