### PR TITLE
Do not add items to the menu if they are not leafs

### DIFF
--- a/src/modules/pass.js
+++ b/src/modules/pass.js
@@ -262,7 +262,12 @@ PassFF.Pass = {
       let itemQuality = hostGroupToMatch.split('\.').length * 100 +
                         hostGroupToMatch.split('\.').length;
       let hostToMatch = hostGroupToMatch;
-
+      /*
+       * Return if item has children since it is a directory!
+       */
+      if (!item.isLeaf()) {
+          break;
+      }
       do {
         if (hostToMatch == tldName) {
           break;


### PR DESCRIPTION
This resolves https://github.com/jvenant/passff/issues/115, where auto fill was incorrectly using the directory name as username