### PR TITLE
Fix for #147: Add strings to German translation

### DIFF
--- a/src/chrome/locale/de-DE/preferences.dtd
+++ b/src/chrome/locale/de-DE/preferences.dtd
@@ -4,6 +4,8 @@
 <!ENTITY tab.script                       "Pass Skript">
 <!ENTITY case-insensitive-search          "Groß-Kleinschreibung ignorieren">
 <!ENTITY case-insensitive-search-tooltip  "Mit dieser Einstellung wird bei der Suche nach einer zur Website passenden Datei keine Unterscheidung zwischen Groß- und Kleinschreibung gemacht">
+<!ENTITY enter-behavior                   "Verhalten der Enter-Taste">
+<!ENTITY enter-behavior-tooltip           "Diese Einstellung bestimmt das Standardverhalten, wenn bei einem markierten Eintrag die Enter-Taste gedrückt wird">
 <!ENTITY fields_description               "Felder werden genutzt, um Daten in deinem Passwort-Repository zu finden. PassFF versucht, den 'login', 'passwort' oder 'url' Wert (entsprechend der Standard-Syntax) oder einen passenden Datensatznamen in den Passwortdaten zu finden.">
 <!ENTITY password_input_names_label       "Namen für 'Passwort'-Eingabefelder">
 <!ENTITY password_input_names_tooltip     "Kommagetrennte Liste von Eingabefeld-Namen. Eingabefelder in der HTML-Seite, die einem dieser Namen entsprechen, werden mit dem Passwort gefüllt.">


### PR DESCRIPTION
This commit adds two strings to the German translation,
* enter-behavior
* enter-behavior-tooltip.
This probably fixes a bug where the preferences window cannot be shown, as the entities are not defined there.

Unfortunately I could not test it, because the addon needs to be verified before my Firefox will run it.