### PR TITLE
Update preferences.css  `code` HTML element in "prefers-color-scheme: dark"

### DIFF
--- a/src/skin/preferences.css
+++ b/src/skin/preferences.css
@@ -70,6 +70,12 @@ fieldset p.text code {
   padding: 0.1em 0.2em;
 }
 
+@media (prefers-color-scheme: dark) {
+  fieldset p.text code {
+    background-color: #23222b;
+  }
+}
+
 fieldset p > label:first-child {
   display: block;
   margin: 0.8rem 0 0.3rem;


### PR DESCRIPTION
Fix the `code` blocks background-color in color-scheme dark

Re-used the `background-color` that was used on other elements when in color-scheme dark, `#23222b`.

![image](https://github.com/user-attachments/assets/4b0e3260-21cf-4614-b1d4-f13866e3c55d)
> The `code` blocks in this screenshot, have the "light background color theme", and the text is not readable; this PR tries to fix only the background.